### PR TITLE
fix: robots meta tag syntax

### DIFF
--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8"/>
 
 <title>{{ page.title }}</title>
-<meta name='robots' content='noindex,nofollow' />
+<meta name="robots" content="noindex, nofollow" />
 <meta name="description" content="{{ page.description }}"/>
 
 <meta name="theme-color" content="#241f31"/>


### PR DESCRIPTION
As it doesn't seem to be interpreted by Jekyll as valid HTML, otherwise the raw response would include it.

![image](https://github.com/user-attachments/assets/eba77e92-55e2-44ac-b4de-73b2e4b035a6)