### PR TITLE
fix: Remove broken link and add missing link

### DIFF
--- a/content/IMAGES.md
+++ b/content/IMAGES.md
@@ -8,15 +8,15 @@ permalink: /images
 
 ## Table of Contents
 {: #table-of-contents}
+- [Security recommendation](#security-recommendation)
 - [Desktop](#desktop)
-  - [Recommended](#recommended)
   - [Stable](#stable)
   - [Beta](#beta)
   - [Experimental](#experimental)
 - [Server](#server)
 
 
-## Security recommendation
+## [Security recommendation](#security-recommendation)
 
 Our Silverblue images utilize GNOME, which is the only desktop environment that secures privileged wayland protocols like screencopy. This means that on non-GNOME systems, applications can access screen content of the entire desktop. This implicitly includes the content of other applications. It\'s primarily for this reason that Silverblue images are recommended. KDE has <a href="https://invent.kde.org/plasma/xdg-desktop-portal-kde/-/issues/7">plans to fix this</a>. GNOME also provides <a href="https://gitlab.gnome.org/GNOME/gnome-desktop/-/issues/213">thumbnailer sandboxing</a> in Gnome Files, which mitigates <a href="https://scarybeastsecurity.blogspot.com/2016/11/0day-exploit-compromising-linux-desktop.html">attacks via thumbnailers</a>. This is a relative recommendation between the desktop environments available on secureblue. GNOME has some extra security niceties like the ones listed above, however it does not solve any of the fundamental issues with desktop linux security. For more details, consult the table below.
 


### PR DESCRIPTION
In the table of contents, the "Recommended" link was broken because it was missing a section. The "Security recommendation" page was missing an entry in the table of contents. Both of those are fixed.