### PR TITLE
fix: Missing newline before Flatpak FAQ

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -40,6 +40,7 @@ permalink: /faq
 - [How do I add a repo?](#adding-repos)
 - [How do I install proprietary codecs?](#install-codecs)
 - [How do I change my DE?](#change-de)
+
 ### [Why is Flatpak included? Should I use Flatpak?](#flatpak)
 {: #flatpak}
 


### PR DESCRIPTION
It caused the table of contents link to be broken and an unneeded tab to appear

![image](https://github.com/user-attachments/assets/0fa0a1c1-d932-4d5e-a769-44f32396f978)
