### PR TITLE
chore: remove <var> wrap from email

### DIFF
--- a/content/CODE_OF_CONDUCT.md
+++ b/content/CODE_OF_CONDUCT.md
@@ -44,7 +44,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <var>secureblueadmin@proton.me</var>.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at secureblueadmin@proton.me.
 
 All complaints will be reviewed and investigated promptly and fairly.
 


### PR DESCRIPTION
This prevents the invocation of an email decoder script, allowing the site to be fully scriptless.