### PR TITLE
docs: Add Atom feed for Releases

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -223,7 +223,7 @@ To subscribe to release notifications, on the secureblue GitHub page, click "Wat
 
 <img alt="GitHub screenshot" src="/assets/release-notifications.png" />
 
-If you prefer to use an Atom feed, supported by many RSS clients, you can use the feed provided by GitHub, [appending .atom to the Releases.](https://github.com/secureblue/secureblue/releases.atom)
+If you prefer to use an Atom feed, supported by many RSS clients, you can use the [feed provided by GitHub](https://github.com/secureblue/secureblue/releases.atom).
 
 ### [Why don't my AppImages work?](#appimage)
 {: #appimage}

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -223,6 +223,8 @@ To subscribe to release notifications, on the secureblue GitHub page, click "Wat
 
 <img alt="GitHub screenshot" src="/assets/release-notifications.png" />
 
+If you prefer to use an Atom feed, supported by many RSS clients, you can use the feed provided by GitHub, [appending .atom to the Releases.](https://github.com/secureblue/secureblue/releases.atom)
+
 ### [Why don't my AppImages work?](#appimage)
 {: #appimage}
 


### PR DESCRIPTION
This an addition to the "How do I get notified of new releases?" FAQ portion, adding Atom feed, provided by GitHub.