### PR TITLE
docs: Update INSTALL.md

### DIFF
--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -221,7 +221,7 @@ ujust audit-secureblue
 
 A lot of technical issues is covered in the [FAQ](/faq). For new users, these topics are particularly important to read:
 
-- [Why are Bluetooth is disabled? How do I enable them?] (/faq#bluetooth)
+- [Why Bluetooth is disabled? How do I enable it?] (/faq#bluetooth)
 - [Why doesn’t my Xwayland app work?] (/faq#xwayland)
 - [How do I install my VPN?](/faq#vpn) 
 - [Why I am unable to start containers?] (/faq#container-userns)

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -223,8 +223,9 @@ A lot of technical issues are covered in the [FAQ](/faq). For new users, the fol
 
 - [Why Bluetooth is disabled? How do I enable it?](/faq#bluetooth)
 - [Why doesn’t my Xwayland app work?](/faq#xwayland)
-- [An app I use won’t start due to a malloc issue. How do I fix it?](/faq#standard-malloc) 
-- [How do I install my VPN?](/faq#vpn) 
+- [An app I use won’t start due to a malloc issue. How do I fix it?](/faq#standard-malloc)
+- [Why don’t my appimages work?](/faq#appimage)
+- [How do I install my VPN?](/faq#vpn)
 - [Why I am unable to start containers?](/faq#container-userns)
 
 ### [Kernel argument tuning](#kargs)

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -228,7 +228,12 @@ ujust audit-secureblue
 ### [Read the FAQ](#faq)
 {: #faq}
 
-Lots of important stuff is covered in the [FAQ](/faq). If you're having an issue, it's probably covered there already. AppImage toggles, GNOME extension toggles, Xwayland toggles, etc.
+A lot of technical issues is covered in the [FAQ](/faq). For new users, these topics are particularly important to read:
+
+- [Why are Bluetooth is disabled? How do I enable them?] (/faq#bluetooth)
+- [Why doesn’t my Xwayland app work?] (/faq#xwayland)
+- [How do I install my VPN?](/faq#vpn) 
+- [Why I am unable to start containers?] (/faq#container-userns)
 
 ### [Kernel argument tuning](#kargs)
 {: #kargs}

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -219,7 +219,7 @@ ujust audit-secureblue
 ### [Read the FAQ](#faq)
 {: #faq}
 
-A lot of technical issues is covered in the [FAQ](/faq). For new users, these topics are particularly important to read:
+A lot of technical issues are covered in the [FAQ](/faq). For new users, these topics are particularly important to read:
 
 - [Why Bluetooth is disabled? How do I enable it?] (/faq#bluetooth)
 - [Why doesn’t my Xwayland app work?] (/faq#xwayland)

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -207,6 +207,15 @@ The secureblue Secure Boot key should automatically enroll after installation, w
 ujust enroll-secureblue-secure-boot-key
 ```
 
+### [Enable Bluetooth (if needed!)](#bluetooth)
+{: #bluetooth}
+
+Bluetooth connectivity is off by default. If you have bluetooth devices (e.g. earbuds) you can toggle it on:
+
+```
+ujust toggle-bluetooth-modules
+```
+
 ### [Validation](#validation)
 {: #validation}
 

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -219,7 +219,7 @@ ujust audit-secureblue
 ### [Read the FAQ](#faq)
 {: #faq}
 
-A lot of technical issues are covered in the [FAQ](/faq). For new users, the following topics are particularly **important** to read:
+A lot of technical issues are covered in the [FAQ](/faq). For new users, the following topics are particularly important to read:
 
 - [Why Bluetooth is disabled? How do I enable it?](/faq#bluetooth)
 - [Why doesn’t my Xwayland app work?](/faq#xwayland)

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -219,7 +219,7 @@ ujust audit-secureblue
 ### [Read the FAQ](#faq)
 {: #faq}
 
-A lot of technical issues are covered in the [FAQ](/faq). For new users, these topics are particularly **important** to read:
+A lot of technical issues are covered in the [FAQ](/faq). For new users, the following topics are particularly **important** to read:
 
 - [Why Bluetooth is disabled? How do I enable it?](/faq#bluetooth)
 - [Why doesn’t my Xwayland app work?](/faq#xwayland)

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -207,15 +207,6 @@ The secureblue Secure Boot key should automatically enroll after installation, w
 ujust enroll-secureblue-secure-boot-key
 ```
 
-### [Enable Bluetooth (if needed!)](#bluetooth)
-{: #bluetooth}
-
-Bluetooth connectivity is off by default. If you have bluetooth devices (e.g. earbuds) you can toggle it on:
-
-```
-ujust toggle-bluetooth-modules
-```
-
 ### [Validation](#validation)
 {: #validation}
 

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -219,12 +219,13 @@ ujust audit-secureblue
 ### [Read the FAQ](#faq)
 {: #faq}
 
-A lot of technical issues are covered in the [FAQ](/faq). For new users, these topics are particularly important to read:
+A lot of technical issues are covered in the [FAQ](/faq). For new users, these topics are particularly **important** to read:
 
-- [Why Bluetooth is disabled? How do I enable it?] (/faq#bluetooth)
-- [Why doesn’t my Xwayland app work?] (/faq#xwayland)
+- [Why Bluetooth is disabled? How do I enable it?](/faq#bluetooth)
+- [Why doesn’t my Xwayland app work?](/faq#xwayland)
+- [An app I use won’t start due to a malloc issue. How do I fix it?](/faq#standard-malloc) 
 - [How do I install my VPN?](/faq#vpn) 
-- [Why I am unable to start containers?] (/faq#container-userns)
+- [Why I am unable to start containers?](/faq#container-userns)
 
 ### [Kernel argument tuning](#kargs)
 {: #kargs}


### PR DESCRIPTION
As mentioned in [these messages](https://discord.com/channels/1202086019298500629/1383669313856081991/1383672132592074763), @RoyalOughtness  and myself highlighted that new users must know that bluetooth is toggled off by default during the installation process, and that they can enable it post-install.