### PR TITLE
docs: add cross-platform verification, swap torrent instructions

### DIFF
--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -122,20 +122,31 @@ winget install -e --id GnuPG.GnuPG
 winget install -e --id uutils.coreutils
 ```
 
-To use the `sha256sum` command in the instructions below, you must then **restart PowerShell** and run:
+To temporarily enable the `sha256sum` command, you must then **restart PowerShell** and run:
 ```
 function sha256sum {
     coreutils.exe sha256sum @args
 }
 ```
 
-###### macOS and Linux
-If `gpg --version` gives a `command not found` error, then you do not have GPG installed. You can get this by installing [Homebrew](https://brew.sh/), then:
+###### macOS
+
+In the terminal, install [Homebrew](https://brew.sh/) if you haven't already. Then:
+```
+brew install gnupg coreutils
+```
+
+To temporarily enable the `sha256sum` command, run:
+```
+export PATH="$(brew --prefix coreutils)/libexec/gnubin:$PATH"
+```
+
+###### Linux
+
+If `gpg --version` gives a `command not found` error, then you do not have GPG installed. You can get this via your distribution's package manager, or by installing [Homebrew](https://brew.sh/), then:
 ```
 brew install gnupg
 ```
-
-Alternatively, Linux users can use their existing distribution's package manager.
 
 ##### For torrent users
 

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -137,32 +137,9 @@ brew install gnupg
 
 Alternatively, Linux users can use their existing distribution's package manager.
 
-##### For all users
-
-First command:
-```
-gpgv --keyring ./secureblue-keyring.gpg "${IMAGE_NAME}.iso-CHECKSUM"
-```
-
-Expected output:
-```
-gpgv: Signature made Wed 04 Jun 2025 12:49:39 AM PDT
-gpgv:                using EDDSA key 26B4463ED8F313BC7E3FBDF9D9223AF0F47B3E41
-gpgv: Good signature from "secureblueadmin <secureblueadmin@proton.me>"
-```
-
-Second command:
-```
-sha256sum -c "${IMAGE_NAME}.iso-CHECKSUM"
-```
-
-Expected output:
-```
-IMAGE_NAME.iso: OK
-sha256sum: WARNING: 8 lines are improperly formatted
-```
-
 ##### For torrent users
+
+Before downloading, torrent users should check their torrent is authentic.
 
 First command:
 ```
@@ -184,6 +161,33 @@ sha256sum -c "${IMAGE_NAME}.iso.torrent-CHECKSUM"
 Expected output:
 ```
 IMAGE_NAME.iso.torrent: OK
+sha256sum: WARNING: 8 lines are improperly formatted
+```
+
+##### For all users
+
+After downloading the ISO, you should verify it.
+
+First command:
+```
+gpgv --keyring ./secureblue-keyring.gpg "${IMAGE_NAME}.iso-CHECKSUM"
+```
+
+Expected output:
+```
+gpgv: Signature made Wed 04 Jun 2025 12:49:39 AM PDT
+gpgv:                using EDDSA key 26B4463ED8F313BC7E3FBDF9D9223AF0F47B3E41
+gpgv: Good signature from "secureblueadmin <secureblueadmin@proton.me>"
+```
+
+Second command:
+```
+sha256sum -c "${IMAGE_NAME}.iso-CHECKSUM"
+```
+
+Expected output:
+```
+IMAGE_NAME.iso: OK
 sha256sum: WARNING: 8 lines are improperly formatted
 ```
 

--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -110,7 +110,32 @@ Things to remember during installation:
 #### [ISO Verification](#verification)
 {: #verification}
 
-You should now have the ISO with its corresponding CHECKSUM file, the keyring file, and if you opted to use a torrent, the torrent file with its corresponding CHECKSUM file. Use following commands to verify the ISO (where `${IMAGE_NAME}` corresponds to the filename of the ISO you downloaded). If you're on Windows, the tools used below are available on [Chocolatey](https://chocolatey.org/). If you're on a Mac, the tools used below are available on [Homebrew](https://brew.sh/).
+You should now have the ISO with its corresponding CHECKSUM file, the keyring file, and if you opted to use a torrent, the torrent file with its corresponding CHECKSUM file. Use following commands to verify the ISO (where `${IMAGE_NAME}` corresponds to the filename of the ISO you downloaded).
+
+##### Installing prerequisites
+
+###### Windows
+
+Open PowerShell as a regular user to run these commands:
+```
+winget install -e --id GnuPG.GnuPG
+winget install -e --id uutils.coreutils
+```
+
+To use the `sha256sum` command in the instructions below, you must then **restart PowerShell** and run:
+```
+function sha256sum {
+    coreutils.exe sha256sum @args
+}
+```
+
+###### macOS and Linux
+If `gpg --version` gives a `command not found` error, then you do not have GPG installed. You can get this by installing [Homebrew](https://brew.sh/), then:
+```
+brew install gnupg
+```
+
+Alternatively, Linux users can use their existing distribution's package manager.
 
 ##### For all users
 


### PR DESCRIPTION
55413a11984774e3cef3ad43f6556049d75e11ad:
- Adds instructions to install gpg and coreutils on Windows
- Adds powershell function to make `sha256sum` usage consistent

f1af688abafe750cb16c17b43578a666868d7103:
- Moves torrent verification to be before ISO verification, as you don't want to download an unverified torrent.