### PR TITLE
fix: layer funionfs instead of zfs-fuse (close #138)

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -292,7 +292,7 @@ AppImages depend on fuse2, which is unmaintained and depends on a SUID root bina
 For example:
 
 ```
-rpm-ostree install zfs-fuse
+rpm-ostree install funionfs
 ```
 
 ### [Why don't KDE Vaults work?](#kde-vaults)


### PR DESCRIPTION
swap zfs-fuse for funionfs:

https://github.com/secureblue/secureblue.dev/issues/138#issuecomment-3137866744:

> ```
> for pkg in $(dnf repoquery --whatrequires fuse); do
>     count=$(dnf repoquery --requires $pkg | sort -u | wc -l)
>     echo "$pkg: $count"
> done
> ```
> 
> has one winner, funionfs. It requires fuse, libfuse and libc only, and weighs 70 KB.
> 
> FunionFS implements a union filesystem in userspace using FUSE. FUSE
> provides a Linux kernel module which allows virtual filesystems to be written
> in userspace.
> 
> It first appeared in the repos in 2008, so will hopefully stick around
