### PR TITLE
docs(platforms): Specify that Discord is preferred for questions

### DIFF
--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -39,7 +39,7 @@ to secureblueadmin@proton.me
 ## [I Have a Question](#i-have-a-question)
 {: #i-have-a-question}
 
-If you want to ask a question, you are welcome to do so in [our Discord channel](https://discord.gg/qMTv5cKfbF).
+If you want to ask a question, you are welcome to do so in [our Discord server](https://discord.gg/qMTv5cKfbF).
 
 ## [I Want To Contribute](#i-want-to-contribute)
 {: #i-want-to-contribute}

--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -39,7 +39,7 @@ to secureblueadmin@proton.me
 ## [I Have a Question](#i-have-a-question)
 {: #i-have-a-question}
 
-If you want to ask a question, opening a [GitHub issue](https://github.com/secureblue/secureblue) for it is preferred, but [Discord](https://discord.gg/qMTv5cKfbF) is available as well.
+If you want to ask a question, you are welcome to do so in [our Discord channel](https://discord.gg/qMTv5cKfbF).
 
 ## [I Want To Contribute](#i-want-to-contribute)
 {: #i-want-to-contribute}


### PR DESCRIPTION
As of [this commit](https://github.com/secureblue/secureblue/commit/90e9c827f9884d28ea8fa52c5ca1591473dfa876), it is recommended to direct questions to Discord, this commit updates website docs accordingly