### PR TITLE
docs: add FAQ item about gaming on secureblue

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -236,11 +236,9 @@ Alternatively, you can download a WireGuard profile config from your VPN provide
 
 Broadly speaking, gaming support on secureblue is similar to gaming on mainstream desktop Linux distros such as Fedora: if a game can be run on desktop Linux, you should be able to run it on secureblue.
 
-However, some security hardening is enabled by default that may need to be disabled for certain games to run. For example, many games require [Xwayland](#xwayland) to be enabled, some games require [anticheat support](#anticheat), and 32-bit programs require [enabling 32-bit support](/articles/kargs#32bit).
+However, some hardening is enabled by default that may need to be disabled for certain games to run. For example, many games require [Xwayland](#xwayland) to be enabled, some games require [anticheat support](#anticheat), and 32-bit programs require [enabling 32-bit support](/articles/kargs#32bit).
 
-Additionally, some kernel arguments have a negative performance impact. The most impactful is [disabling SMT](/articles/kargs#smt), either unconditionally (with `nosmt=force`) or only if necessary to mitigate a known hardware vulnerability (with `mitigations=auto,nosmt`).
-
-If SMT is disabled, this effectively halves the number of CPU cores; the performance impact of this can be significant (up to around 40%) for highly parallel, CPU-intensive workloads. A few other kernel arguments have a negative performance impact but those are much more minor.
+Additionally, some kernel arguments have a negative performance impact. The most impactful for multithreaded games is [disabling SMT](#smt). A few other kernel arguments have a negative performance impact but those are much more minor.
 
 ### [How do I install Steam?](#steam)
 {: #steam}
@@ -485,6 +483,8 @@ During rpm-ostree operations, it's normal. Outside of that, make sure you follow
 {: #smt}
 
 `mitigations=auto,nosmt` is set on secureblue. This means that if your CPU is vulnerable to attacks that utilize [Simultaneous Multithreading](https://en.wikipedia.org/wiki/Simultaneous_multithreading), SMT will be disabled. There are several other kargs secureblue sets that may also trigger this behavior, including `nosmt=force`, and `l1tf=full,force`.
+
+If SMT is disabled, this effectively halves the number of CPU cores; the performance impact of this can be significant (up to around 40%) for highly parallel, CPU-intensive workloads. On the other hand, for many workloads the impact is much smaller, and it can even slightly improve performance of single-threaded workloads.
 
 ### [Why don't my AppImages work?](#appimage)
 {: #appimage}

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -482,7 +482,7 @@ During rpm-ostree operations, it's normal. Outside of that, make sure you follow
 ### [On secureblue half of my CPU cores are gone. Why is this?](#smt)
 {: #smt}
 
-`mitigations=auto,nosmt` is set on secureblue. This means that if your CPU is vulnerable to attacks that utilize [Simultaneous Multithreading](https://en.wikipedia.org/wiki/Simultaneous_multithreading), SMT will be disabled. There are several other kargs secureblue sets that may also trigger this behavior, including `nosmt=force`, and `l1tf=full,force`.
+The [kernel argument](/articles/kargs) `mitigations=auto,nosmt` is set on secureblue. This means that if your CPU is vulnerable to attacks that utilize [Simultaneous Multithreading](https://en.wikipedia.org/wiki/Simultaneous_multithreading), SMT will be disabled. There are several other kernel arguments secureblue sets that may also trigger this behavior, including `nosmt=force`, and `l1tf=full,force`.
 
 If SMT is disabled, this effectively halves the number of CPU cores; the performance impact of this can be significant (up to around 40%) for highly parallel, CPU-intensive workloads. On the other hand, for many workloads the impact is much smaller, and it can even slightly improve performance of single-threaded workloads.
 

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -35,6 +35,7 @@ permalink: /faq
   - [How do I whitelist a module?](#module-whitelist)
   - [How do I install software?](#software)
   - [How do I install my VPN?](#vpn)
+  - [How is gaming on secureblue?](#gaming)
   - [How do I install Steam?](#steam)
   - [How do I enable anti-cheat support?](#anticheat)
   - [How do I install Docker?](#docker)
@@ -229,6 +230,17 @@ Alternatively, you can download a WireGuard profile config from your VPN provide
 <img alt="Gnome Settings screenshot" src="/assets/gnome-settings-vpn-step4.png" />
 
 {% include alert.html type='note' content='If you get an error that says "Cannot Import VPN", that is likely because the name of the WireGuard configuration file is too long. GNOME Settings will only accept WireGuard configuration files with filenames 15 characters or less.' %}
+
+### [How is gaming on secureblue?](#gaming)
+{: #gaming}
+
+Broadly speaking, gaming support on secureblue is similar to gaming on mainstream desktop Linux distros such as Fedora: if a game can be run on desktop Linux, you should be able to run it on secureblue.
+
+However, some security hardening is enabled by default that may need to be disabled for certain games to run. For example, many games require [Xwayland](#xwayland) to be enabled, some games require [anticheat support](#anticheat), and 32-bit programs require [enabling 32-bit support](/articles/kargs#32bit).
+
+Additionally, some kernel arguments have a negative performance impact. The most impactful is [disabling SMT](/articles/kargs#smt), either unconditionally (with `nosmt=force`) or only if necessary to mitigate a known hardware vulnerability (with `mitigations=auto,nosmt`).
+
+If SMT is disabled, this effectively halves the number of CPU cores; the performance impact of this can be significant (up to around 40%) for highly parallel, CPU-intensive workloads. A few other kernel arguments have a negative performance impact but those are much more minor.
 
 ### [How do I install Steam?](#steam)
 {: #steam}

--- a/content/articles/KARGS.md
+++ b/content/articles/KARGS.md
@@ -11,7 +11,7 @@ permalink: /articles/kargs
 - [Introduction](#introduction)
 - [Standard](#standard)
 - [Additional](#additional)
-  - [Disable 32-bit processes and syscalls](#32-bit)
+  - [Disable 32-bit processes and syscalls](#32bit)
   - [Force disable simultaneous multithreading](#smt)
   - [Unstable kargs](#unstable)
 
@@ -87,7 +87,7 @@ whether to add apply of the 3 sets of kargs detailed below:
 
 ## Disable 32-bit processes and syscalls
 
-{: #32-bit}
+{: #32bit}
 
 {% include alert.html type='note' content='32-bit support is needed by some legacy software, such as Steam.' %}
 


### PR DESCRIPTION
"How is gaming on secureblue" is a frequently asked question in the discord server, and it'd be nice to have an FAQ item on the site to point people to.

Also fix the anchor for the 32-bit section in the kargs article.