### PR TITLE
docs: update FAQ item for KDE splash screen

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -506,10 +506,12 @@ For any other issues you experience with Trivalent, visit Trivalent's dedicated 
 ### [Why is my splash screen disabled on KDE?](#kde-splash-disabled)
 {: #kde-splash-disabled}
 
-The KDE splash screen is currently [broken](https://github.com/secureblue/secureblue/issues/926) if Xwayland is disabled (which is the default on secureblue), due to an [upstream bug](https://discuss.kde.org/t/how-to-disable-xwayland-for-the-plasma-wayland-session/19325/6). secureblue automatically disables it for every user to work around this. If you don't want the splash screen to be automatically disabled, run the following command:
+The KDE splash screen is currently [broken](https://github.com/secureblue/secureblue/issues/926) if Xwayland is disabled (which is the default on secureblue), due to an [upstream bug](https://discuss.kde.org/t/how-to-disable-xwayland-for-the-plasma-wayland-session/19325/6). secureblue automatically disables it for every user to work around this. If you don't want the splash screen to be automatically disabled, run the following commands:
 
 ```
-systemctl disable --user disable-kde-splash.service
+mkdir -p ~/.config/user-tmpfiles.d
+ln -s /dev/null ~/.config/user-tmpfiles.d/ksplashrc.conf
+chmod u+w ~/.config/ksplashrc
 ```
 
 ### [Why is my virtual machine integration broken?](#vm-integration)


### PR DESCRIPTION
Update commands to reflect changes made in secureblue/secureblue#1926. (Note also that the previously given command didn't work, as `systemctl disable --user` can't disable a *globally* enabled user service.)