### PR TITLE
docs: Update the run0 FAQ entry

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -440,7 +440,7 @@ ujust set-xwayland on
 ### [Why do some commands fail when run with run0? (Exit code 203)](#run0-failures)
 {: #run0-failures}
 
-Fedora's SELinux policy causes `run0` to silently fail when run alongside some commands (e.g., dnf). There is already an [open issue](https://github.com/fedora-selinux/selinux-policy/issues/2500) tracking this, and it is expected to be fixed in the future. In the meantime, you can run `run0 -i '<your command>'` or enter a root shell by running `run0` on its own and run the command from there.
+Fedora's SELinux policy causes `run0` to silently fail when run alongside some commands (e.g., dnf). There is already an [open issue](https://github.com/fedora-selinux/selinux-policy/issues/2500) tracking this, and it is expected to be fixed in the future. In the meantime, you can run `run0 -i <your command>` or enter a root shell by running `run0` on its own and run the command from there.
 
 ### [Why I can't install nor use any GNOME user extensions?](#gnome-extensions)
 {: #gnome-extensions}

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -61,7 +61,7 @@ permalink: /faq
   - [Something broke! How do I rollback?](#rollback)
   - [Why can't I install new KDE themes?](#ghns)
   - [Why doesn't my Xwayland app work?](#xwayland)
-  - [Why do some commands fail when run with run0?](#run0-failures)
+  - [Why do some commands fail when run with run0? (Exit code 203)](#run0-failures)
   - [Why I can't install nor use any GNOME user extensions?](#gnome-extensions)
   - [An app I use won't start due to a malloc issue. How do I fix it?](#standard-malloc)
   - [My clock is wrong, and it's not getting automatically set. How do I fix this?](#clock)
@@ -437,10 +437,10 @@ ujust toggle-ghns
 ujust set-xwayland on
 ```
 
-### [Why do some commands fail when run with run0?](#run0-failures)
+### [Why do some commands fail when run with run0? (Exit code 203)](#run0-failures)
 {: #run0-failures}
 
-Fedora's SELinux policy causes `run0` to silently fail when run alongside some commands (e.g., dnf). There is already an [open issue](https://github.com/fedora-selinux/selinux-policy/issues/2500) tracking this, and it is expected to be fixed in the future. In the meantime, you can run `run0 sh -c '<your command>'` or enter a root shell by running `run0` on its own and run the command from there.
+Fedora's SELinux policy causes `run0` to silently fail when run alongside some commands (e.g., dnf). There is already an [open issue](https://github.com/fedora-selinux/selinux-policy/issues/2500) tracking this, and it is expected to be fixed in the future. In the meantime, you can run `run0 -i '<your command>'` or enter a root shell by running `run0` on its own and run the command from there.
 
 ### [Why I can't install nor use any GNOME user extensions?](#gnome-extensions)
 {: #gnome-extensions}


### PR DESCRIPTION
This PR updates the original [run0 FAQ entry](https://secureblue.dev/faq#run0-failures) to include the keywords "Exit code 203" in the title, making it easier for users to find. It also modifies the original workaround `run0 sh -c '<command>'` to the simpler` run0 -i <command>`, which achieves the same result as the original workaround.