### PR TITLE
fix: typos in some articles

### DIFF
--- a/content/articles/BUILD_ARCHITECTURE.md
+++ b/content/articles/BUILD_ARCHITECTURE.md
@@ -24,7 +24,7 @@ permalink: /articles/build-architecture
 ## [Introduction](#introduction)
 {: #introduction}
 
-Supply chain security is a priority for secureblue. During the the build process, we use complementary security mechanisms to protect against a variety of supply chain attack vectors. The documentation below covers each of these mechanisms, the protections they provide, and where secureblue uses these mechanisms.
+Supply chain security is a priority for secureblue. During the build process, we use complementary security mechanisms to protect against a variety of supply chain attack vectors. The documentation below covers each of these mechanisms, the protections they provide, and where secureblue uses these mechanisms.
 
 ## [Definitions](#definitions)
 {: #definitions}

--- a/content/articles/FLATPAK.md
+++ b/content/articles/FLATPAK.md
@@ -30,7 +30,7 @@ You can revert this change by running:
 ujust flatpak-reset-global-overrides
 ```
 
-Note that this will not only undo the the `ujust flatpak-permissions-lockdown` command but also any other global overrides (individual app overrides will not be affected). This also affects flatpak's hardened_malloc integration (which is set by default), so you should run this afterwards:
+Note that this will not only undo the `ujust flatpak-permissions-lockdown` command but also any other global overrides (individual app overrides will not be affected). This also affects flatpak's hardened_malloc integration (which is set by default), so you should run this afterwards:
 
 ```
 ujust harden-flatpak


### PR DESCRIPTION
This PR fixes little typos in the `BUILD_ARCHITECTURE` and `FLATPAK` articles.