### PR TITLE
docs: update KSplash FAQ item

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -508,12 +508,10 @@ For any other issues you experience with Trivalent, visit Trivalent's dedicated 
 ### [Why is my splash screen disabled on KDE?](#kde-splash-disabled)
 {: #kde-splash-disabled}
 
-The KDE splash screen is currently [broken](https://github.com/secureblue/secureblue/issues/926) if Xwayland is disabled (which is the default on secureblue), due to an [upstream bug](https://discuss.kde.org/t/how-to-disable-xwayland-for-the-plasma-wayland-session/19325/6). secureblue automatically disables it for every user to work around this. If you don't want the splash screen to be automatically disabled, run the following commands:
+The KDE splash screen is currently [broken](https://github.com/secureblue/secureblue/issues/926) if Xwayland is disabled (which is the default on secureblue), due to an [upstream bug](https://discuss.kde.org/t/how-to-disable-xwayland-for-the-plasma-wayland-session/19325/6). secureblue automatically disables it for every user to work around this. If you don't want the splash screen to be automatically disabled, run the following command:
 
 ```
-mkdir -p ~/.config/user-tmpfiles.d
-ln -s /dev/null ~/.config/user-tmpfiles.d/ksplashrc.conf
-chmod u+w ~/.config/ksplashrc
+run0 rm /etc/xdg/ksplashrc
 ```
 
 ### [Why is my virtual machine integration broken?](#vm-integration)


### PR DESCRIPTION
Reflects changes in how splash screen is disabled. This should be merged alongside secureblue/secureblue#1997.