### PR TITLE
fix: GitHub Actions as recommended for developers

### DIFF
--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -90,6 +90,7 @@ One of the nice things about the image model is that we can generate an entire O
 We strive towards a model where proposed changes are more thoroughly reviewed and tested by the community. So here's how to do it. If you see a pull request that is opened up on an image you're following, you can leave a review on how it's working for you.
 
 ## [Building with GitHub Actions (recommended)](#building-ga)
+{: #building-ga}
 
 Start from your own fork with a branch for the pull request/feature you want to develop. Follow the instructions [here](https://blue-build.org/how-to/cosign/) to add your own keys to verify your own custom image. From there, it's recommended you go to .github/workflows/build.yml and comment out all of the image variants except the ones you use/intend to test. This drastically speeds up your workflow runtime. Then just go to actions > build-secureblue and select run workflow, making sure you select the branch you just set up.
 

--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -25,6 +25,7 @@ And if you like the project, but just don't have time to contribute, that's fine
   - [Reporting Bugs](#reporting-bugs)
   - [Pull Requests](#pull-requests)
   - [How to test incoming changes](#how-to-test-incoming-changes)
+- [Building with GitHub Actions (recommended)](#building-ga)
 - [Building Locally](#building-locally)
 - [Styleguides](#styleguides)
   - [Commit Messages](#commit-messages)
@@ -88,7 +89,7 @@ One of the nice things about the image model is that we can generate an entire O
 
 We strive towards a model where proposed changes are more thoroughly reviewed and tested by the community. So here's how to do it. If you see a pull request that is opened up on an image you're following, you can leave a review on how it's working for you.
 
-## Building your images with GitHub Actions (recommended)
+## [Building with GitHub Actions (recommended)](#building-ga)
 
 Start from your own fork with a branch for the pull request/feature you want to develop. Follow the instructions [here](https://blue-build.org/how-to/cosign/) to add your own keys to verify your own custom image. From there, it's recommended you go to .github/workflows/build.yml and comment out all of the image variants except the ones you use/intend to test. This drastically speeds up your workflow runtime. Then just go to actions > build-secureblue and select run workflow, making sure you select the branch you just set up.
 

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -368,7 +368,7 @@ Note that Distrobox is not a security tool. It focuses on [integration, not isol
 ### [How do I customize secureblue?](#customization)
 {: #customization}
 
-If you want to add your own customizations on top of secureblue that go beyond installing packages, you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For local development, [building locally](/contributing#building-locally) is the recommended approach.
+If you want to add your own customizations on top of secureblue that go beyond installing packages, you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For development, forking [building with github actions](/contributing#building-ga) is the recommended approach.
 
 ### [How do I add a repo?](#adding-repos)
 {: #adding-repos}

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -380,7 +380,7 @@ Note that Distrobox is not a security tool. It focuses on [integration, not isol
 ### [How do I customize secureblue?](#customization)
 {: #customization}
 
-If you want to add your own customizations on top of secureblue that go beyond installing packages, unless you are [contributing](/contriuting), you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For development purposes, forking then [building with GitHub Actions](/contributing#building-ga) is the recommended approach.
+If you want to add your own customizations on top of secureblue that go beyond installing packages, unless you are [contributing](/contributing), you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For secureblue development purposes, forking then [building with GitHub Actions](/contributing#building-ga) is the recommended approach.
 
 ### [How do I add a repo?](#adding-repos)
 {: #adding-repos}

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -368,7 +368,7 @@ Note that Distrobox is not a security tool. It focuses on [integration, not isol
 ### [How do I customize secureblue?](#customization)
 {: #customization}
 
-If you want to add your own customizations on top of secureblue that go beyond installing packages, you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For development, forking [building with github actions](/contributing#building-ga) is the recommended approach.
+If you want to add your own customizations on top of secureblue that go beyond installing packages, unless you are [contributing](/contriuting), you are advised strongly against forking. Instead, create a repo for your own image by using the [BlueBuild template](https://github.com/blue-build/template), then change your `base-image` to a secureblue image. This allows you to apply your customizations to secureblue in a concise and maintainable way, without the need to constantly sync with upstream. For development purposes, forking then [building with GitHub Actions](/contributing#building-ga) is the recommended approach.
 
 ### [How do I add a repo?](#adding-repos)
 {: #adding-repos}


### PR DESCRIPTION
Note that this does not update the GA section itself as detailed in https://github.com/secureblue/secureblue.dev/issues/305, this is just a quick correction.

The information on GA in contributing still has information that is out of date or missing. This needs to be addressed in a future PR to help new contributors.