### PR TITLE
docs: update link for Trivalent SELinux policy

### DIFF
--- a/content/FEATURES.md
+++ b/content/FEATURES.md
@@ -11,7 +11,7 @@ permalink: /features
 
 - Install and enable [hardened_malloc](https://github.com/GrapheneOS/hardened_malloc) globally, including for Flatpaks.
 - Install [Trivalent](https://github.com/secureblue/Trivalent), our security-focused, Chromium-based browser inspired by [Vanadium](https://github.com/GrapheneOS/Vanadium). <sup>[Why Chromium-based?](https://grapheneos.org/usage#web-browsing)</sup> <sup>[Why not a Flatpak?](https://forum.vivaldi.net/post/669805)</sup>
-- SELinux [confinement](https://github.com/secureblue/secureblue/tree/live/files/scripts/selinux/trivalent) for Trivalent.
+- SELinux [confinement](https://github.com/secureblue/Trivalent/blob/live/build/trivalent.te) for Trivalent.
 - Kernel hardening via sysctl. <sup>[details](https://github.com/secureblue/secureblue/blob/live/files/system/usr/lib/sysctl.d/55-hardening.conf)</sup>
 - Kernel hardening via kernel arguments. <sup>[details](/articles/kargs)</sup>
 - Configure chronyd to use Network Time Security (NTS).


### PR DESCRIPTION
The policy was moved in secureblue/secureblue#2045.