### PR TITLE
fix: misplaced anchor in VM FAQ

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -295,7 +295,6 @@ ujust uninstall-docker
 Consider using Podman over Docker as it is already installed on secureblue images.
 
 ### [How do I run virtual machines?](#libvirt)
-
 {: #libvirt}
 
 [Libvirt](https://libvirt.org/index.html), [QEMU](https://www.qemu.org/), the


### PR DESCRIPTION
There can't be a blank line between the header and the anchor or it places the anchor in a separate paragraph.