### PR TITLE
Replace dupe issue to open one to avoid is fixed

### DIFF
--- a/content/INSTALL.md
+++ b/content/INSTALL.md
@@ -24,7 +24,7 @@ permalink: /install
 ## [Pre-install](#pre-install)
 {: #pre-install}
 
-{% include alert.html type='note' content='The cross-platform Fedora Media Writer is the <em>official, tested, and supported</em> method for the creation of bootable media. Instructions are available in the <a href="https://docs.fedoraproject.org/en-US/fedora/latest/preparing-boot-media/">Fedora documentation</a>. Do <a href="https://github.com/ventoy/Ventoy/issues/2795">not</a> use Ventoy.' %}
+{% include alert.html type='note' content='The cross-platform Fedora Media Writer is the <em>official, tested, and supported</em> method for the creation of bootable media. Instructions are available in the <a href="https://docs.fedoraproject.org/en-US/fedora/latest/preparing-boot-media/">Fedora documentation</a>. Do <a href="https://github.com/ventoy/Ventoy/issues/3224">not</a> use Ventoy.' %}
 
 Before installation, the following checks are recommended:
 


### PR DESCRIPTION
This PR replaces [Closed issue](https://github.com/ventoy/Ventoy/issues/2795) to [Open](https://github.com/ventoy/Ventoy/issues/3224) one for why user should not use Ventoy.