### PR TITLE
feat: changes for local version

### DIFF
--- a/_config.yaml
+++ b/_config.yaml
@@ -11,3 +11,5 @@ defaults:
 
 exclude: ["README.md"]
 include: ["_headers"]
+
+local: false

--- a/_config_local.yaml
+++ b/_config_local.yaml
@@ -1,0 +1,4 @@
+url: file:///usr/share/secureblue/website
+# or wherever we wanna put it idk
+
+local: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -4,7 +4,9 @@
             <li {% if include.content == "" %}aria-current="page"{% endif %}><a href="/"><img src="/assets/icons/favicon.svg" alt=""/>secureblue</a></li>
             <li {% if include.content == "features" %}aria-current="page"{% endif %}><a href="/features">Features</a></li>
             <li {% if include.content == "images" %}aria-current="page"{% endif %}><a href="/images">Images</a></li>
+            {%- unless site.local == true %}
             <li {% if include.content == "install" %}aria-current="page"{% endif %}><a href="/install">Install</a></li>
+            {%- endunless %}
             <li {% if include.content == "post-install" %}aria-current="page"{% endif %}><a href="/post-install">Post-Install</a></li>
             <li {% if include.content == "faq" %}aria-current="page"{% endif %}><a href="/faq">FAQ</a></li>
             <li {% if include.content == "contributing" %}aria-current="page"{% endif %}><a href="/contributing">Contributing</a></li>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -3,7 +3,9 @@
     <div>
         <h1 id="secureblue"><a href="#secureblue">secureblue</a></h1>
         <p>A security-focused desktop and server linux operating system.</p>
+        {%- unless site.local == true %}
         <a class="button" href="/install">Get secureblue</a>
+        {%- endunless %}
     </div>
 
     <figure class="device-img">

--- a/_includes/meta.html
+++ b/_includes/meta.html
@@ -15,14 +15,14 @@
 <meta property="og:title" content="{{ page.title }}">
 <meta property="og:description" content="{{ page.description }}">
 <meta property="og:type" content="website">
-<meta property="og:image" content="https://secureblue.dev/assets/icons/opengraph.png">
+<meta property="og:image" content="{{ site.url }}/assets/icons/opengraph.png">
 <meta property="og:image:width" content="512">
 <meta property="og:image:height" content="512">
 <meta property="og:image:alt" content="secureblue logo">
 <meta property="og:site_name" content="secureblue">
-<meta property="og:url" content="https://secureblue.dev/{{ include.content }}">
+<meta property="og:url" content="{{ site.url }}/{{ include.content }}">
 
-<link rel="canonical" href="https://secureblue.dev/{{ include.content }}">
+<link rel="canonical" href="{{ site.url }}/{{ include.content }}">
 
 <link rel="icon" type="image/png" href="/assets/icons/favicon-96x96.png" sizes="96x96">
 <link rel="icon" type="image/svg+xml" href="/assets/icons/favicon.svg">

--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -443,7 +443,7 @@ You can install `kde-connect` by running `rpm-ostree install kde-connect` and th
 ### [How do I change my DE?](#change-de)
 {: #change-de}
 
-Choose whatever you like from the [available options](https://secureblue.dev/images) by running `ujust rebase-secureblue`.
+Choose whatever you like from the [available options](/images) by running `ujust rebase-secureblue`.
 
 ### [How do I enable kernel modules?](#enable-kernel-modules)
 {: #enable-kernel-modules}


### PR DESCRIPTION
A concept demonstration after a talk in the secureblue Discord. If we were to include a version of the website within secureblue images, so that documentation like the FAQ can be opened offline; this would allow us to create a version of the site that has irrelevant information removed, like the installation information.

The build process is the same, except you append `--config _config.yaml,_config_local.yaml` to the `jekyll` command.

Here's the appearance now:
<img width="1280" height="720" alt="online" src="https://github.com/user-attachments/assets/9fc105ff-3f21-4199-a0c3-595a5960ecc8" />

And here's the offline appearance:
<img width="1280" height="720" alt="local" src="https://github.com/user-attachments/assets/2d10abb9-29cd-4b83-8004-f7615dccc3ba" />

Marked as a draft since this alone wouldn't implement anything, and there's also a placeholder comment for the undiscussed detail of where the site would be stored :p

I won't attempt it for now, but ideally we should exclude unnecessary files from the output as well, like the install page itself, or the various icon files. (maybe for the latter, some could be symlinked to the files installed by [`branding`](https://github.com/secureblue/branding)?)