### PR TITLE
docs: typo: with -> without

### DIFF
--- a/content/FAQ.md
+++ b/content/FAQ.md
@@ -667,7 +667,7 @@ ujust toggle-mac-randomization
 
 The [userspace interface to the kernel crypto API](https://www.kernel.org/doc/html/latest/crypto/userspace-if.html) is seldom used, provides substantial attack surface, and has been the source of various exploits, including [Copy Fail](https://copy.fail/). As a proactive security measure, secureblue uses SELinux policy to block all userspace processes from using this API by denying access to `AF_ALG` sockets.
 
-Unfortunately, iwd currently relies on this interface and is not usable with it. (This is not an issue for most users: wpa_supplicant, not iwd, is the default wireless daemon on secureblue.) If you want to use iwd anyway, you can disable this custom SELinux policy with the following command:
+Unfortunately, iwd currently relies on this interface and is not usable without it. (This is not an issue for most users: wpa_supplicant, not iwd, is the default wireless daemon on secureblue.) If you want to use iwd anyway, you can disable this custom SELinux policy with the following command:
 
 ```
 run0 -i semodule -v -d deny_af_alg


### PR DESCRIPTION
accidentally a word...