### PR TITLE
fix: Linux is properly capitalized 

### DIFF
--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -2,7 +2,7 @@
 
     <div>
         <h1 id="secureblue"><a href="#secureblue">secureblue</a></h1>
-        <p>A security-focused desktop and server linux operating system.</p>
+        <p>A security-focused desktop and server Linux operating system.</p>
         <a class="button" href="/install">Get secureblue</a>
     </div>
 

--- a/content/INDEX.md
+++ b/content/INDEX.md
@@ -1,6 +1,6 @@
 ---
-title: "secureblue: A security-focused desktop and server linux operating system."
-description: "A security-focused desktop and server linux operating system."
+title: "secureblue: A security-focused desktop and server Linux operating system."
+description: "A security-focused desktop and server Linux operating system."
 permalink: /
 ---
 


### PR DESCRIPTION
Linux is a proper noun and so should always have the first letter capitalized <3