### PR TITLE
docs: update pre-commit hook instructions

### DIFF
--- a/content/CONTRIBUTING.md
+++ b/content/CONTRIBUTING.md
@@ -84,18 +84,14 @@ The secureblue repository runs a number of code quality and consistency checks i
 
 To configure pre-commit hooks in your local copy of the repository, install either [prek](https://prek.j178.dev/) or [pre-commit](https://pre-commit.com/) (secureblue uses `.pre-commit-config.yaml`, which is compatible with both), then run either `prek install` or `pre-commit install`.
 
-To be able to run pre-commit hooks for [ShellCheck](https://www.shellcheck.net/) and [ty](https://docs.astral.sh/ty/) (a Python type-checker), you will need to install them on your system (for example via Homebrew). You will also need to set up a Python virtual environment with the dependencies from `pyproject.toml` installed.
+To be able to run the pre-commit hook for [ShellCheck](https://www.shellcheck.net/), you will need to install ShellCheck on your system (for example via Homebrew).
 
 In summary, the following commands (run from the repository root) will install the necessary tools and set up the repo to run the pre-commit hooks:
 
 ```
-brew install prek shellcheck ty uv
+brew install prek shellcheck
 prek install
-uv venv
-uv pip install -r pyproject.toml
 ```
-
-(Feel free to use a different Python package manager in place of `uv` if you prefer; these steps are purely for local development.)
 
 #### Before submitting a pull request
 


### PR DESCRIPTION
Now that secureblue has switched to the official ty pre-commit hook, separate installation of ty and the Python venv are no longer required to run pre-commit hooks.