### PR TITLE
fix: Correct support platforms

### DIFF
--- a/content/INDEX.md
+++ b/content/INDEX.md
@@ -17,4 +17,4 @@ secureblue is for those whose first priority is using Linux, and second priority
 ## [Support and community](#support-and-community)
 {: #support-and-community}
 
-Both [GitHub issues](https://github.com/secureblue/secureblue/issues) and [Discord](https://discord.gg/qMTv5cKfbF) are available for support from the secureblue community.
+[Discord](https://discord.gg/qMTv5cKfbF) is available for support from the secureblue community.


### PR DESCRIPTION
"Both [GitHub issues](https://github.com/secureblue/secureblue/issues) and [Discord](https://discord.gg/qMTv5cKfbF) are available for support from the secureblue community." is inaccurate.

GitHub issues are only available for creating or viewing bug/vulnerability reports or feature requests. Attempting to use GitHub issues for "Project questions, support, and discussions with the community" redirects to Discord. Therefore GitHub issues does not provide "support from the secureblue community".

This project centralizes discussion and support on [Discord](https://consumerrights.wiki/w/Discord), the site's index page should accurately reflect that reality.